### PR TITLE
Offset based pseudo linked lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *build*/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.30)
 project(test-sort C)
 set(CMAKE_C_STANDARD 99)
-add_executable(tester main.c sort_absorb_last.c)
+add_executable(tester main.c sort_absorb_last.c particle.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,3 +2,23 @@ cmake_minimum_required(VERSION 3.30)
 project(test-sort C)
 set(CMAKE_C_STANDARD 99)
 add_executable(tester main.c sort_absorb_last.c particle.c)
+
+include(CTest)
+
+foreach(i RANGE 1 10)
+    add_test(NAME test_sort_offsets_${i} COMMAND tester ${i} 0)
+endforeach ()
+foreach(i RANGE 20 100 10)
+    add_test(NAME test_sort_offsets_${i} COMMAND tester ${i} 0)
+endforeach ()
+foreach(i RANGE 200 1000 100)
+    add_test(NAME test_sort_offsets_${i} COMMAND tester ${i} 0)
+endforeach ()
+foreach(i RANGE 2000 10000 1000)
+    add_test(NAME test_sort_offsets_${i} COMMAND tester ${i} 0)
+endforeach ()
+
+
+#foreach(i RANGE 1 10)
+#    add_test(NAME test_sort_pointers_${i} COMMAND tester ${i} 1)
+#endforeach ()

--- a/main.c
+++ b/main.c
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
   // Start with all particles in 'good' list because they just passed through a component
   for (long i=0; i < n_particles; i++){
     good[i].this = particles + i;
-    good[i].prev = i ? NULL : good + i - 1;
+    good[i].prev = i == 0 ? NULL : good + i - 1;
     good[i].next = i < n_particles - 1 ? good + i + 1 : NULL;
   }
   // Set up the offsets for the good list

--- a/main.c
+++ b/main.c
@@ -4,10 +4,17 @@
 #include "particle.h"
 #include "sort_absorb_last.h"
 
-int main() {
-  long n_particles = 20;
+int main(int argc, char *argv[]) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: %s <n_particles> <1 ? pointers : offsets>\n", argv[0]);
+    return 1;
+  }
+  long n_particles = strtol(argv[1], NULL, 10);
+  long pointers_or_offsets = strtol(argv[2], NULL, 10);
+
   _class_particle * particles = calloc(n_particles, sizeof(_class_particle));
   particle_node * good = calloc(n_particles, sizeof(particle_node));
+  long * nexts = calloc(n_particles, sizeof(long));
 
   for (long i=0; i < n_particles; i++){
     particles[i].x = (double) i;
@@ -37,21 +44,54 @@ int main() {
     good[i].prev = i ? NULL : good + i - 1;
     good[i].next = i < n_particles - 1 ? good + i + 1 : NULL;
   }
-
-  long weight;
-  printf("Pre sorted\n");
+  // Set up the offsets for the good list
   for (long i=0; i < n_particles; i++){
+    nexts[i] = i + 1; // i < n_particles - 1 ? i + 1 : n_particles + 1;
+  }
+
+  printf("Pre sorted\n");
+  for (long i=0; i < 1 + 0 *n_particles; i++){
     printf("Particle %ld: x=%f, _absorbed=%d, rand=%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0]);
   }
 
 //  long returned = sort_absorb_last(particles, n_particles, buffer, n_buffer, 1, &weight);
 
-  long returned = sort_absorb_list(good, n_particles, &weight);
-
-  printf("Returned %ld particles with weight %ld\n", returned, weight);
-  for (long i=0; i < n_particles; i++){
-    printf("Particle %ld: x=%f, _absorbed=%d, rand=%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0]);
+  long weight;
+  long returned;
+  if (pointers_or_offsets){
+    printf("Sorting pointers\n");
+    returned = sort_absorb_list(good, n_particles, &weight);
+  } else {
+    printf("Sorting offsets\n");
+    returned = sort_absorb_offset(particles, nexts, n_particles, &weight);
   }
+
+  // the expected result is that all particles with _absorbed == 1 are unmoved, but overwritten by one of the good
+  // particles in the list. Since every third particle is good, the pattern should be
+  // 0, 0, 3, 3, 6, 9, 6, 12, 15, 9, 18, 21, 12, 24, 27, 15, 30, 33, 18, 36, 39 ...
+  int correct_count = 0;
+  int counter = -3;
+  for (long i=0; i<n_particles; i++){
+    if (particles[i]._absorbed == 0 && particles[i].randstate[0] == (double)i){
+      long expected = (i % 3) == 0 ? i : (counter+=3) ;
+      if (particles[i].x == (double)expected){
+        ++correct_count;
+      } else {
+        printf("Particle %ld: x=%f, _absorbed=%d, rand=%f, expected %ld\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0], expected);
+      }
+    } else {
+      printf("Particle %ld: x=%f, _absorbed=%d, rand=%f matching%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0], particles[i].randstate[0] - (double) i);
+    }
+    if (counter >= n_particles - 3) counter = -3;
+  }
+  printf("Correct count: %d of %ld\n", correct_count, n_particles);
+
+//
+//
+//  printf("\nReturned %ld particles with weight %ld\n", returned, weight);
+//  for (long i=0; i < n_particles; i++){
+//    printf("Particle %ld: x=%f, _absorbed=%d, rand=%f thread=%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0], particles[i].randstate[5]);
+//  }
 
   // pretend we're going on with this linked list scheme, so de-tangle the particle list:
   for (long i=0; i < n_particles; i++){
@@ -61,5 +101,6 @@ int main() {
 
   free(particles);
   free(good);
-  return 0;
+  free(nexts);
+  return correct_count == n_particles && returned == n_particles ? 0 : 1;
 }

--- a/main.c
+++ b/main.c
@@ -95,8 +95,7 @@ int main(int argc, char *argv[]) {
 
   // pretend we're going on with this linked list scheme, so de-tangle the particle list:
   for (long i=0; i < n_particles; i++){
-    good[i].prev = i ? NULL : good + i - 1;
-    good[i].next = i < n_particles - 1 ? good + i + 1 : NULL;
+    good[i].prev = i > 0 ? good + i - 1 : NULL;
   }
 
   free(particles);

--- a/main.c
+++ b/main.c
@@ -5,10 +5,12 @@
 #include "sort_absorb_last.h"
 
 int main() {
-  long n_particles = 102;
+  long n_particles = 20;
   long n_buffer = n_particles;
   _class_particle * particles = calloc(n_particles, sizeof(_class_particle));
   _class_particle * buffer = calloc(n_buffer, sizeof(_class_particle));
+
+  particle_node * good = calloc(n_particles, sizeof(particle_node));
 
   for (long i=0; i < n_particles; i++){
     particles[i].x = (double) i;
@@ -31,8 +33,23 @@ int main() {
     particles[i].randstate[5] = (double) i;
     particles[i].randstate[6] = (double) i;
   }
+
+  // Start with all particles in 'good' list because they just passed through a component
+  for (long i=0; i < n_particles; i++){
+    good[i].this = particles + i;
+    good[i].prev = i ? NULL : good + i - 1;
+    good[i].next = i < n_particles - 1 ? good + i + 1 : NULL;
+  }
+
   long weight;
-  long returned = sort_absorb_last(particles, n_particles, buffer, n_buffer, 1, &weight);
+  printf("Pre sorted\n");
+  for (long i=0; i < n_particles; i++){
+    printf("Particle %ld: x=%f, _absorbed=%d, rand=%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0]);
+  }
+
+//  long returned = sort_absorb_last(particles, n_particles, buffer, n_buffer, 1, &weight);
+
+  long returned = sort_absorb_list(good, n_particles, &weight);
 
   printf("Returned %ld particles with weight %ld\n", returned, weight);
   for (long i=0; i < n_particles; i++){
@@ -41,5 +58,7 @@ int main() {
 
   free(particles);
   free(buffer);
+
+  free(good);
   return 0;
 }

--- a/main.c
+++ b/main.c
@@ -6,10 +6,7 @@
 
 int main() {
   long n_particles = 20;
-  long n_buffer = n_particles;
   _class_particle * particles = calloc(n_particles, sizeof(_class_particle));
-  _class_particle * buffer = calloc(n_buffer, sizeof(_class_particle));
-
   particle_node * good = calloc(n_particles, sizeof(particle_node));
 
   for (long i=0; i < n_particles; i++){
@@ -56,9 +53,13 @@ int main() {
     printf("Particle %ld: x=%f, _absorbed=%d, rand=%f\n", i, particles[i].x, particles[i]._absorbed, particles[i].randstate[0]);
   }
 
-  free(particles);
-  free(buffer);
+  // pretend we're going on with this linked list scheme, so de-tangle the particle list:
+  for (long i=0; i < n_particles; i++){
+    good[i].prev = i ? NULL : good + i - 1;
+    good[i].next = i < n_particles - 1 ? good + i + 1 : NULL;
+  }
 
+  free(particles);
   free(good);
   return 0;
 }

--- a/particle.c
+++ b/particle.c
@@ -34,19 +34,21 @@ particle_node * particle_list_after(particle_node * nodes, long index) {
 
 long connect_particle_lists(particle_node ** nodes, long node_count, int loop) {
   long first;
-  for (first = 0; first < node_count && nodes[first]->this == NULL; first++);
+  for (first = 0; first < node_count && nodes[first] != NULL && nodes[first]->this == NULL; first++);
   if (first == node_count) {
     // no particles to connect
     return 0;
   }
   particle_node * end = particle_list_end(nodes[first]);
-  for (long next=first + 1; next < node_count; next++) {
-    if (nodes[next]->this){
-      // found a particle, connect it to the list
-      end->next = nodes[next];
-      nodes[next]->prev = end;
-      // move the end pointer to the new end
-      end = particle_list_end(nodes[next]);
+  if (end != NULL) {
+    for (long next = first + 1; next < node_count; next++) {
+      if (nodes[next] != NULL && nodes[next]->this) {
+        // found a particle, connect it to the list
+        end->next = nodes[next];
+        nodes[next]->prev = end;
+        // move the end pointer to the new end
+        end = particle_list_end(nodes[next]);
+      }
     }
   }
   // nodes[first] now connects all particles in each list, in order,
@@ -56,7 +58,7 @@ long connect_particle_lists(particle_node ** nodes, long node_count, int loop) {
   }
   // count the number of particles in the list
   long count = particle_list_length(nodes[0]);
-  if (loop){
+  if (loop && end != NULL && nodes[0] != NULL){
     // connect the last node to the first
     end->next = nodes[0];
     nodes[0]->prev = end;
@@ -106,7 +108,7 @@ void print_particle_list(particle_node * nodes){
 }
 
 particle_node * particle_list_rewind(particle_node * nodes){
-  if (nodes->this == NULL && nodes->prev != NULL) {
+  if (nodes != NULL && nodes->this == NULL && nodes->prev != NULL) {
     particle_node * remove = nodes;
     nodes = nodes->prev;
     free(remove);
@@ -116,4 +118,76 @@ particle_node * particle_list_rewind(particle_node * nodes){
     nodes = nodes->prev;
   }
   return nodes;
+}
+
+
+long particle_nodes_end(long node, long * next_node, long len) {
+  while (node < len && next_node[node] < len) {
+    node = next_node[node];
+  }
+  return node;
+}
+
+
+long particle_nodes_length(long node, long * nexts, long len) {
+  long count = 0;
+  while (node < len) {
+    if (count >= len){
+      fprintf(stderr, "Error: particle_nodes_length: node count %ld exceeds length %ld\n", count, len);
+      return count;
+    }
+    count++;
+    node = nexts[node];
+  }
+  return count;
+}
+
+
+long particle_node_after(long node, long * nexts, long len, long after) {
+  long count = 0;
+  while (count < after && node < len) {
+    count++;
+    node = nexts[node];
+  }
+  return node;
+}
+
+
+long connect_particle_nodes(long * nodes, long * nexts, long len, long node_count, int loop) {
+  long first;
+  for (first = 0; first < node_count && nodes[first] >= len; first++);
+  if (first == node_count) {
+    // no particles to connect
+    return 0;
+  }
+  long end = particle_nodes_end(nodes[first], nexts, len);
+  for (long next=first + 1; next < node_count; next++) {
+    if (nodes[next] < len){
+      // found a particle, connect it to the list
+      nexts[end] = nodes[next];
+      // move the end pointer to the new end
+      end = particle_nodes_end(nexts[end], nexts, len);
+    }
+  }
+  // nodes[first] now connects all particles in each list, in order,
+  // but we want the _first_ node to go through all particles
+  if (first){
+    nodes[0] = nodes[first];
+  }
+  // count the number of particles in the list
+  long count = particle_nodes_length(nodes[0], nexts, len);
+  if (loop){
+    // connect the last node to the first
+    nexts[end] = nodes[0];
+  }
+  return count;
+}
+
+
+
+void print_particle_node(long node, long * nexts, _class_particle * particles, long len){
+  while (node < len) {
+    print_particle(particles + node);
+    node = nexts[node];
+  }
 }

--- a/particle.c
+++ b/particle.c
@@ -112,7 +112,7 @@ particle_node * particle_list_rewind(particle_node * nodes){
     particle_node * remove = nodes;
     nodes = nodes->prev;
     free(remove);
-    nodes->next = NULL;;
+    nodes->next = NULL;
   }
   while (nodes != NULL && nodes->prev != NULL) {
     nodes = nodes->prev;

--- a/particle.c
+++ b/particle.c
@@ -1,0 +1,119 @@
+#include <memory.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "particle.h"
+
+
+long particle_list_length(particle_node * nodes) {
+  long count = 0;
+  while (nodes != NULL) {
+    count++;
+    nodes = nodes->next;
+  }
+  return count;
+}
+
+
+particle_node * particle_list_end(particle_node * nodes) {
+  while (nodes != NULL && nodes->this != NULL && nodes->next != NULL) {
+    nodes = nodes->next;
+  }
+  return nodes;
+}
+
+
+particle_node * particle_list_after(particle_node * nodes, long index) {
+  long count = 0;
+  while (nodes != NULL && count < index) {
+    count++;
+    nodes = nodes->next;
+  }
+  return nodes;
+}
+
+
+long connect_particle_lists(particle_node ** nodes, long node_count, int loop) {
+  long first;
+  for (first = 0; first < node_count && nodes[first]->this == NULL; first++);
+  if (first == node_count) {
+    // no particles to connect
+    return 0;
+  }
+  particle_node * end = particle_list_end(nodes[first]);
+  for (long next=first + 1; next < node_count; next++) {
+    if (nodes[next]->this){
+      // found a particle, connect it to the list
+      end->next = nodes[next];
+      nodes[next]->prev = end;
+      // move the end pointer to the new end
+      end = particle_list_end(nodes[next]);
+    }
+  }
+  // nodes[first] now connects all particles in each list, in order,
+  // but we want the _first_ node to go through all particles
+  if (first){
+    nodes[0] = nodes[first];
+  }
+  // count the number of particles in the list
+  long count = particle_list_length(nodes[0]);
+  if (loop){
+    // connect the last node to the first
+    end->next = nodes[0];
+    nodes[0]->prev = end;
+  }
+  return count;
+}
+
+
+void particle_list_free(particle_node * nodes, long count, int warn){
+  particle_node * next;
+  while (nodes != NULL && count > 0) {
+    next = nodes->next;
+    free(nodes);
+    nodes = next;
+    count--;
+  }
+}
+
+
+void particle_node_copy(particle_node * dest, particle_node * src, int copy_rand_state){
+  _class_particle p = *src->this;
+  if (!copy_rand_state) {
+    p.randstate[0] = dest->this->randstate[0];
+    p.randstate[1] = dest->this->randstate[1];
+    p.randstate[2] = dest->this->randstate[2];
+    p.randstate[3] = dest->this->randstate[3];
+    p.randstate[4] = dest->this->randstate[4];
+    p.randstate[5] = dest->this->randstate[5];
+    p.randstate[6] = dest->this->randstate[6];
+  }
+  memcpy(dest->this, &p, sizeof(_class_particle));
+}
+
+void print_particle(_class_particle * p){
+  printf("Particle: x=%f, y=%f, z=%f, vx=%f, vy=%f, vz=%f, sx=%f, sy=%f, sz=%f, p=%f, t=%f, _absorbed=%d\n",
+         p->x, p->y, p->z,
+         p->vx, p->vy, p->vz,
+         p->sx, p->sy, p->sz,
+         p->p, p->t,
+         p->_absorbed);
+}
+void print_particle_list(particle_node * nodes){
+  while (nodes != NULL && nodes->this != NULL) {
+    print_particle(nodes->this);
+    nodes = nodes->next;
+  }
+}
+
+particle_node * particle_list_rewind(particle_node * nodes){
+  if (nodes->this == NULL && nodes->prev != NULL) {
+    particle_node * remove = nodes;
+    nodes = nodes->prev;
+    free(remove);
+    nodes->next = NULL;;
+  }
+  while (nodes != NULL && nodes->prev != NULL) {
+    nodes = nodes->prev;
+  }
+  return nodes;
+}

--- a/particle.h
+++ b/particle.h
@@ -26,6 +26,7 @@ struct particle_node_struct {
 
 typedef struct particle_node_struct particle_node;
 
+
 long particle_list_length(particle_node * nodes);
 particle_node * particle_list_end(particle_node * nodes);
 particle_node * particle_list_after(particle_node * nodes, long index);
@@ -40,3 +41,9 @@ void print_particle(_class_particle * p);
 void print_particle_list(particle_node * nodes);
 
 particle_node * particle_list_rewind(particle_node * nodes);
+
+
+long connect_particle_nodes(long * nodes, long * offsets, long len, long node_count, int loop);
+long particle_node_after(long node, long * offsets, long len, long after);
+
+void print_particle_node(long node, long * nexts, _class_particle * particles, long len);

--- a/particle.h
+++ b/particle.h
@@ -17,3 +17,26 @@ struct particle_struct {
 };
 
 typedef struct particle_struct _class_particle;
+
+struct particle_node_struct {
+  _class_particle * this;
+  struct particle_node_struct * prev;
+  struct particle_node_struct * next;
+};
+
+typedef struct particle_node_struct particle_node;
+
+long particle_list_length(particle_node * nodes);
+particle_node * particle_list_end(particle_node * nodes);
+particle_node * particle_list_after(particle_node * nodes, long index);
+
+long connect_particle_lists(particle_node ** nodes, long node_count, int loop);
+
+void particle_list_free(particle_node * nodes, long count, int warn);
+
+void particle_node_copy(particle_node * dest, particle_node * src, int copy_rand_state);
+
+void print_particle(_class_particle * p);
+void print_particle_list(particle_node * nodes);
+
+particle_node * particle_list_rewind(particle_node * nodes);

--- a/sort_absorb_last.c
+++ b/sort_absorb_last.c
@@ -1,231 +1,191 @@
 #include <math.h>
 #include <memory.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include "sort_absorb_last.h"
-//
-//long sort_absorb_last(_class_particle * particles, long p_len, _class_particle * buffer, long b_len, long split, long* multiplier) {
-//#define SAL_THREADS 10 // num parallel sections
-//
-//  if (multiplier != NULL) *multiplier = -1; // set default out value for multiplier
-//  long newlen = 0;
-//  long los[SAL_THREADS]; // target array startidxs
-//  long lens[SAL_THREADS]; // target array sublens
-//  long l = floor(p_len/(SAL_THREADS-1)); // subproblem_len
-//  long ll = p_len - l*(SAL_THREADS-1); // last_subproblem_len
-//
-//  // TODO: The l vs ll is too simplistic, since ll can become much larger
-//  // than l, resulting in idling. We should distribute lengths more evenly.
-//
-//  // step 1: sort sub-arrays
-//#pragma acc parallel loop present(particles[0:b_len], buffer[0:b_len])
-//  for (long tidx=0; tidx<SAL_THREADS; tidx++) {
-//    long lo = l*tidx;
-//    long loclen = l;
-//    if (tidx==(SAL_THREADS-1)) loclen = ll; // last sub-problem special case
-//    long i = lo;
-//    long j = lo + loclen - 1;
-//
-//    // write into buffer at i and j
-//#pragma acc loop seq
-//    while (i < j) {
-//#pragma acc loop seq
-//      while (!particles[i]._absorbed && i<j) {
-//        buffer[i] = particles[i];
-//        i++;
-//      }
-//#pragma acc loop seq
-//      while (particles[j]._absorbed && i<j) {
-//        buffer[j] = particles[j];
-//        j--;
-//      }
-//      if (i < j) {
-//        buffer[j] = particles[i];
-//        buffer[i] = particles[j];
-//        i++;
-//        j--;
-//      }
-//    }
-//    // transfer edge case
-//    if (i==j)
-//      buffer[i] = particles[i];
-//
-//    lens[tidx] = i - lo;
-//    if (i==j && !particles[i]._absorbed) lens[tidx]++;
-//  }
-//
-//  // determine lo's
-//  long accumlen = 0;
-//#pragma acc loop seq
-//  for (long idx=0; idx<SAL_THREADS; idx++) {
-//    los[idx] = accumlen;
-//    accumlen = accumlen + lens[idx];
-//  }
-//
-//  // step 2: write non-absorbed sub-arrays to psorted/output from the left
-//#pragma acc parallel loop present(buffer[0:b_len])
-//  for (long tidx=0; tidx<SAL_THREADS; tidx++) {
-//    long j, k;
-//#pragma acc loop seq
-//    for (long i=0; i<lens[tidx]; i++) {
-//      j = i + l*tidx;
-//      k = i + los[tidx];
-//      particles[k] = buffer[j];
-//    }
-//  }
-//  //for (int ii=0;ii<accumlen;ii++) printf("%ld ", (psorted[ii]->_absorbed));
-//
-//  // return (no SPLIT)
-//  if (split != 1)
-//    return accumlen;
-//
-//  // SPLIT - repeat the non-absorbed block N-1 times, where len % accumlen = N + R
-//  long mult = b_len / accumlen; // TODO: possibly use a new arg, bufferlen, rather than len
-//
-//  // not enough space for full-block split, return
-//  if (mult <= 1)
-//    return accumlen;
-//
-//  // copy non-absorbed block
-//#pragma acc parallel loop present(particles[0:b_len])
-//  for (long tidx = 0; tidx < accumlen; tidx++) { // tidx: thread index
-//    _class_particle sourcebuffer;
-//    _class_particle targetbuffer;
-//    // assign reduced weight to all particles
-//    particles[tidx].p = particles[tidx].p / (double) mult;
-//#pragma acc loop seq
-//    for (long bidx = 1; bidx < mult; bidx++) { // bidx: block index
-//      // preserve absorbed particle (for randstate)
-//      sourcebuffer = particles[bidx*accumlen + tidx];
-//      // buffer full particle struct
-//      targetbuffer = particles[tidx];
-//      // reassign previous randstate
-//      targetbuffer.randstate[0] = sourcebuffer.randstate[0];
-//      targetbuffer.randstate[1] = sourcebuffer.randstate[1];
-//      targetbuffer.randstate[2] = sourcebuffer.randstate[2];
-//      targetbuffer.randstate[3] = sourcebuffer.randstate[3];
-//      targetbuffer.randstate[4] = sourcebuffer.randstate[4];
-//      targetbuffer.randstate[5] = sourcebuffer.randstate[5];
-//      targetbuffer.randstate[6] = sourcebuffer.randstate[6];
-//      // apply
-//      particles[bidx*accumlen + tidx] = targetbuffer;
-//    }
-//  }
-//
-//  // set out split multiplier value
-//  if (multiplier) *multiplier = mult;
-//
-//  // return expanded array size
-//  return accumlen * mult;
-//}
 
 
 long sort_absorb_last(_class_particle * particles, long len, _class_particle * pbuffer, long buffer_len, long flag_split, long* multiplier) {
-#define SAL_THREADS 10 // num parallel sections
+#define SAL_THREADS 3 // num parallel sections
 
   if (multiplier != NULL) *multiplier = -1; // set default out value for multiplier
-
-  long target_start_index[SAL_THREADS]; // target array startidxs
-  long target_sub_length[SAL_THREADS]; // target array sublens
 
   long at_least = len / SAL_THREADS;  // every thread handles at least this many particles
   long remainder = len % SAL_THREADS; // and the first remainder threads handle one more
 
-  // step 1: sort sub-arrays
+  particle_node * good[SAL_THREADS];
+  particle_node * bad[SAL_THREADS];
+
+  for (long i=0; i<SAL_THREADS; i++) {
+    good[i] = calloc(1, sizeof(particle_node));
+    good[i]->this = NULL;
+    good[i]->prev = NULL;
+    good[i]->next = NULL;
+    bad[i] = calloc(1, sizeof(particle_node));
+    bad[i]->this = NULL;
+    bad[i]->prev = NULL;
+    bad[i]->next = NULL;
+  }
+
+  // divide the particles into two linked lists: absorbed and not-absorbed
 #pragma acc parallel loop present(particles[0:b_len], buffer[0:b_len])
   for (long thread=0; thread < SAL_THREADS; thread++) {
-    long chunk = thread < remainder ? at_least + 1 : at_least;
-    long first = (chunk * thread) + (thread < remainder ? 0 : remainder);
-    long i = first, j = first + chunk - 1;
 
-    // write into pbuffer at i and j
-#pragma acc loop seq
-    while (i < j) {
-#pragma acc loop seq
-      while (!particles[i]._absorbed && i<j) {
-        pbuffer[i] = particles[i];
-        i++;
-      }
-#pragma acc loop seq
-      while (particles[j]._absorbed && i<j) {
-        pbuffer[j] = particles[j];
-        j--;
-      }
-      if (i < j) {
-        pbuffer[j] = particles[i];
-        pbuffer[i] = particles[j];
-        i++;
-        j--;
+    long chunk = thread <= remainder ? at_least + 1 : at_least;
+    long first = (chunk * thread) + (thread <= remainder ? 0 : remainder);
+    long i = first, j = first + chunk;
+
+    for (long k=i; k<j; k++) {
+      if (particles[k]._absorbed) {
+        // add to absorbed list
+        bad[thread]->this = particles + k;
+        bad[thread]->next = calloc(1, sizeof(particle_node *));
+        bad[thread]->next->prev = bad[thread];
+        bad[thread] = bad[thread]->next;
+      } else {
+        // add to absorbed list
+        good[thread]->this = particles + k;
+        good[thread]->next = calloc(1, sizeof(particle_node *));
+        good[thread]->next->prev = good[thread];
+        good[thread] = good[thread]->next;
       }
     }
-    target_sub_length[thread] = i - first;
+    // go back to the start of this thread's list
+    good[thread] = particle_list_rewind(good[thread]);
+    bad[thread] = particle_list_rewind(bad[thread]);
+  }
+  // identify the first thread to have found a good particle
+  long total_good = connect_particle_lists(good, SAL_THREADS, 1); // loop the good list
+  long total_bad = connect_particle_lists(bad, SAL_THREADS, 0); // don't loop the bad list
 
-    // transfer edge case
-    if (i==j) {
-      pbuffer[i] = particles[i];
-      // and handle the case where the last particle is non-absorbed
-      if (!particles[i]._absorbed) {
-        target_sub_length[thread]++;
+  printf("Total good: %ld, Total bad: %ld\n(bad ones:)\n", total_good, total_bad);
+  print_particle_list(bad[0]);
+  printf("\n");
+
+  if (total_good && total_bad){
+    // with finite good and bad, we have work to do.
+    // parallelize over the number of threads, each needs to fill-in total_bad / SAL_THREADS
+    at_least = total_bad / SAL_THREADS;
+    remainder = total_bad % SAL_THREADS;
+    // move the pointers to their per-thread offsets
+    for (long i=1; i<SAL_THREADS; i++) {
+      bad[i] = particle_list_after(bad[i-1], i < remainder ? at_least + 1 : at_least);
+      // good might loop-around, this is fine.
+      good[i] = particle_list_after(good[i-1], i < remainder ? at_least + 1 : at_least);
+    }
+    // overwrite the bad list with the good list
+#pragma acc parallel loop present(bad[0:SAL_THREADS, good[0:SAL_THREADS])
+    for (long thread=0; thread < SAL_THREADS; thread++) {
+      for (long i=0; i < (thread <= remainder ? at_least + 1 : at_least); ++i){
+        particle_node_copy(bad[thread], good[thread], 0); // don't copy the rand state from good to bad
+        bad[thread] = bad[thread]->next;
+        good[thread] = good[thread]->next;
+      }
+    }
+  }
+  // the first entry in good and bad point to a node which is connected to all nodes of that type,
+  // so freeing only that node's list will free the whole thing.
+  particle_list_free(good[0], total_good, 0); // don't warn due to looped list
+  particle_list_free(bad[0], total_bad, 1);
+
+  if (!total_good || !total_bad) {
+    // no particles are good _or_ none are bad, return since we can't split
+    return total_bad ? 0 : len;
+  }
+  return len;
+}
+
+
+long sort_absorb_list(particle_node * input, long len, long * multiplier){
+#define SAL_THREADS 3 // num parallel sections
+
+  if (multiplier != NULL) *multiplier = -1; // set default out value for multiplier
+
+  long at_least = len / SAL_THREADS;  // every thread handles at least this many particles
+  long remainder = len % SAL_THREADS; // and the first remainder threads handle one more
+
+  particle_node * good[SAL_THREADS];
+  particle_node * bad[SAL_THREADS];
+  particle_node * start[SAL_THREADS];
+
+  // identify per-thread starting points before sorting, since this method breaks once ->next is modified
+  for (long thread = 0; thread < SAL_THREADS; ++thread) {
+    long chunk = thread <= remainder ? at_least + 1 : at_least;
+    long first = (chunk * thread) + (thread <= remainder ? 0 : remainder);
+    start[thread] = particle_list_after(input, first); // input + first
+  }
+
+  for (long thread = 0; thread < SAL_THREADS; ++thread){
+    long chunk = thread <= remainder ? at_least + 1 : at_least;
+    particle_node * node = start[thread];
+    // ensure the ->prev link in removed
+    node->prev = NULL;
+    good[thread] = NULL;
+    bad[thread] = NULL;
+    particle_node * move;
+    for (long i = 0; i < chunk; ++i){
+      if (node == NULL || node->this == NULL) break;
+      int absorbed = node->this->_absorbed;
+      move = absorbed ? bad[thread] : good[thread];
+      if (move != NULL){
+        // add to the end of the list
+        move->next = node;
+        node->prev = move;
+      } else {
+        // this is the first node in the good/bad list
+        node->prev = NULL;
+      }
+      if (absorbed){
+        bad[thread] = node;
+      } else {
+        good[thread] = node;
+      }
+      // store the last node in the good/bad list
+      move = node;
+      // move the pointer for the input list
+      node = node->next;
+      // unlink the good/bad list end node
+      move->next = NULL;
+    }
+    // go back to the start of this thread's list
+    good[thread] = particle_list_rewind(good[thread]);
+    bad[thread] = particle_list_rewind(bad[thread]);
+  }
+  // identify the first thread to have found a good particle
+  // TODO Since we're modifying the pointers in the input list, we should not create a loop
+  //      otherwise we may have trouble 'straightening' the list later.
+  long total_good = connect_particle_lists(good, SAL_THREADS, 1); // *do not* loop the good list
+  long total_bad = connect_particle_lists(bad, SAL_THREADS, 0); // don't loop the bad list
+
+  if (total_good && total_bad){
+    // with finite good and bad, we have work to do.
+    // parallelize over the number of threads, each needs to fill-in total_bad / SAL_THREADS
+    at_least = total_bad / SAL_THREADS;
+    remainder = total_bad % SAL_THREADS;
+    // move the pointers to their per-thread offsets
+    for (long i=1; i<SAL_THREADS; i++) {
+      bad[i] = particle_list_after(bad[i-1], i <= remainder ? at_least + 1 : at_least);
+      // good might loop-around, this is fine.
+      good[i] = particle_list_after(good[i-1], i <= remainder ? at_least + 1 : at_least);
+    }
+    // overwrite the bad list with the good list
+#pragma acc parallel loop present(input[0:len], bad[0:SAL_THREADS], good[0:SAL_THREADS])
+    for (long thread=0; thread < SAL_THREADS; thread++) {
+      for (long i=0; i < (thread <= remainder ? at_least + 1 : at_least); ++i){
+        printf("Thread %ld, i %ld\n", thread, i);
+        particle_node_copy(bad[thread], good[thread], 0); // don't copy the rand state from good to bad
+        bad[thread] = bad[thread]->next;
+        good[thread] = good[thread]->next;
       }
     }
   }
 
-  // determine lo's
-  long moved = 0;
-  // FIXME should this cumulative sum really be a seq loop? It only loops over the number of threads.
-#pragma acc loop seq
-  for (long idx=0; idx<SAL_THREADS; idx++) {
-    target_start_index[idx] = moved;
-    // TOOD can this not be moved += target_sub_length[idx]?
-    moved = moved + target_sub_length[idx];
+  if (total_good && multiplier){
+    // if we have good particles, we need to return the multiplier
+    // which is how much we've scaled up the good particles
+    *multiplier = 1 + total_bad / total_good;
   }
 
-  // step 2: write non-absorbed sub-arrays to psorted/output from the left
-  // FIXME can this gather be parallelized efficiently?
-#pragma acc parallel loop present(buffer[0:b_len])
-  for (long thread=0; thread < SAL_THREADS; thread++) {
-    long j = thread < remainder ? (at_least + 1) * thread : at_least * thread + remainder;
-    long k = target_start_index[thread];
-#pragma acc loop seq
-    for (long i=0; i < target_sub_length[thread]; i++) {
-      particles[k + i] = pbuffer[j + i];
-    }
-  }
-
-  // SPLIT - repeat the non-absorbed block N-1 times, where len % moved = N + R
-  long mult = buffer_len / moved; // TODO: possibly use a new arg, bufferlen, rather than len
-
-  // no flag_split or not enough space for full-block flag_split, return
-  if (flag_split != 1 || mult <= 1) {
-    return moved;
-  }
-
-  // copy non-absorbed block
-#pragma acc parallel loop present(particles[0:b_len])
-  for (long thread = 0; thread < moved; thread++) { // thread: thread index
-    // assign reduced weight to all particles
-    particles[thread].p = particles[thread].p / (double) mult;
-    // copy this particle to replicate (mult-1) times, preserving randstate
-    _class_particle source = particles[thread];
-#pragma acc loop seq
-    for (long bidx = 1; bidx < mult; bidx++) { // bidx: block index
-      long i = bidx * moved + thread; // this strided access can't be good for performance
-      // reassign previous randstate
-      source.randstate[0] = particles[i].randstate[0];
-      source.randstate[1] = particles[i].randstate[1];
-      source.randstate[2] = particles[i].randstate[2];
-      source.randstate[3] = particles[i].randstate[3];
-      source.randstate[4] = particles[i].randstate[4];
-      source.randstate[5] = particles[i].randstate[5];
-      source.randstate[6] = particles[i].randstate[6];
-      // copy the not-absorbed particle with the absorbed-particle's random state
-      // FIXME: Since no consideration is given to whether the destination was a moved non-absorbed particle,
-      //        there will be particles with the same random state in the output.
-      particles[i] = source;
-    }
-  }
-
-  // set out flag_split multiplier value
-  if (multiplier) *multiplier = mult;
-
-  // return expanded array size
-  return moved * mult;
+  // if there were any good particles, we have ensured there are len good ones output
+  return total_good ? len : 0;
 }

--- a/sort_absorb_last.c
+++ b/sort_absorb_last.c
@@ -5,97 +5,6 @@
 #include "sort_absorb_last.h"
 
 
-long sort_absorb_last(_class_particle * particles, long len, _class_particle * pbuffer, long buffer_len, long flag_split, long* multiplier) {
-#define SAL_THREADS 3 // num parallel sections
-
-  if (multiplier != NULL) *multiplier = -1; // set default out value for multiplier
-
-  long at_least = len / SAL_THREADS;  // every thread handles at least this many particles
-  long remainder = len % SAL_THREADS; // and the first remainder threads handle one more
-
-  particle_node * good[SAL_THREADS];
-  particle_node * bad[SAL_THREADS];
-
-  for (long i=0; i<SAL_THREADS; i++) {
-    good[i] = calloc(1, sizeof(particle_node));
-    good[i]->this = NULL;
-    good[i]->prev = NULL;
-    good[i]->next = NULL;
-    bad[i] = calloc(1, sizeof(particle_node));
-    bad[i]->this = NULL;
-    bad[i]->prev = NULL;
-    bad[i]->next = NULL;
-  }
-
-  // divide the particles into two linked lists: absorbed and not-absorbed
-#pragma acc parallel loop present(particles[0:b_len], buffer[0:b_len])
-  for (long thread=0; thread < SAL_THREADS; thread++) {
-
-    long chunk = thread <= remainder ? at_least + 1 : at_least;
-    long first = (chunk * thread) + (thread <= remainder ? 0 : remainder);
-    long i = first, j = first + chunk;
-
-    for (long k=i; k<j; k++) {
-      if (particles[k]._absorbed) {
-        // add to absorbed list
-        bad[thread]->this = particles + k;
-        bad[thread]->next = calloc(1, sizeof(particle_node *));
-        bad[thread]->next->prev = bad[thread];
-        bad[thread] = bad[thread]->next;
-      } else {
-        // add to absorbed list
-        good[thread]->this = particles + k;
-        good[thread]->next = calloc(1, sizeof(particle_node *));
-        good[thread]->next->prev = good[thread];
-        good[thread] = good[thread]->next;
-      }
-    }
-    // go back to the start of this thread's list
-    good[thread] = particle_list_rewind(good[thread]);
-    bad[thread] = particle_list_rewind(bad[thread]);
-  }
-  // identify the first thread to have found a good particle
-  long total_good = connect_particle_lists(good, SAL_THREADS, 1); // loop the good list
-  long total_bad = connect_particle_lists(bad, SAL_THREADS, 0); // don't loop the bad list
-
-  printf("Total good: %ld, Total bad: %ld\n(bad ones:)\n", total_good, total_bad);
-  print_particle_list(bad[0]);
-  printf("\n");
-
-  if (total_good && total_bad){
-    // with finite good and bad, we have work to do.
-    // parallelize over the number of threads, each needs to fill-in total_bad / SAL_THREADS
-    at_least = total_bad / SAL_THREADS;
-    remainder = total_bad % SAL_THREADS;
-    // move the pointers to their per-thread offsets
-    for (long i=1; i<SAL_THREADS; i++) {
-      bad[i] = particle_list_after(bad[i-1], i < remainder ? at_least + 1 : at_least);
-      // good might loop-around, this is fine.
-      good[i] = particle_list_after(good[i-1], i < remainder ? at_least + 1 : at_least);
-    }
-    // overwrite the bad list with the good list
-#pragma acc parallel loop present(bad[0:SAL_THREADS, good[0:SAL_THREADS])
-    for (long thread=0; thread < SAL_THREADS; thread++) {
-      for (long i=0; i < (thread <= remainder ? at_least + 1 : at_least); ++i){
-        particle_node_copy(bad[thread], good[thread], 0); // don't copy the rand state from good to bad
-        bad[thread] = bad[thread]->next;
-        good[thread] = good[thread]->next;
-      }
-    }
-  }
-  // the first entry in good and bad point to a node which is connected to all nodes of that type,
-  // so freeing only that node's list will free the whole thing.
-  particle_list_free(good[0], total_good, 0); // don't warn due to looped list
-  particle_list_free(bad[0], total_bad, 1);
-
-  if (!total_good || !total_bad) {
-    // no particles are good _or_ none are bad, return since we can't split
-    return total_bad ? 0 : len;
-  }
-  return len;
-}
-
-
 long sort_absorb_list(particle_node * input, long len, long * multiplier){
 #define SAL_THREADS 3 // num parallel sections
 
@@ -113,15 +22,16 @@ long sort_absorb_list(particle_node * input, long len, long * multiplier){
     long chunk = thread <= remainder ? at_least + 1 : at_least;
     long first = (chunk * thread) + (thread <= remainder ? 0 : remainder);
     start[thread] = particle_list_after(input, first); // input + first
+    good[thread] = NULL;
+    bad[thread] = NULL;
   }
 
   for (long thread = 0; thread < SAL_THREADS; ++thread){
     long chunk = thread <= remainder ? at_least + 1 : at_least;
     particle_node * node = start[thread];
+    if (node == NULL || node->this == NULL) continue;
     // ensure the ->prev link in removed
     node->prev = NULL;
-    good[thread] = NULL;
-    bad[thread] = NULL;
     particle_node * move;
     for (long i = 0; i < chunk; ++i){
       if (node == NULL || node->this == NULL) break;
@@ -188,3 +98,177 @@ long sort_absorb_list(particle_node * input, long len, long * multiplier){
   // if there were any good particles, we have ensured there are len good ones output
   return total_good ? len : 0;
 }
+
+long chunk_size(long len, long threads, long thread){
+  long at_least = len / threads;  // every thread handles at least this many particles
+  long remainder = len % threads; // and the first remainder threads handle one more
+  return thread < remainder ? at_least + 1 : at_least;
+}
+
+long chunk_start(long len, long threads, long thread){
+  long at_least = len / threads;  // every thread handles at least this many particles
+  long remainder = len % threads; // and the first remainder threads handle one more
+  return thread < remainder ? (at_least + 1) * thread : (at_least + 1) * remainder + at_least * (thread - remainder);
+}
+
+
+long sort_absorb_offset(_class_particle * particles, long * nexts, long len, long * multiplier){
+#define SAL_THREADS 3 // num parallel sections
+
+  if (multiplier != NULL) *multiplier = -1; // set default out value for multiplier
+
+  long at_least = len / SAL_THREADS;  // every thread handles at least this many particles
+  long remainder = len % SAL_THREADS; // and the first remainder threads handle one more
+  if (at_least < 1 && remainder){
+    // fewer than SAL_THREADS particles, ideally pass this off to a single thread algorithm
+    at_least = 1;
+    remainder = 0;
+  }
+
+  long good[SAL_THREADS];
+  long bad[SAL_THREADS];
+
+  long first_index[SAL_THREADS];
+  long first_good[SAL_THREADS];
+  long first_bad[SAL_THREADS];
+
+  // identify per-thread starting points before sorting, since this method breaks once ->next is modified
+  for (long thread = 0; thread < SAL_THREADS; ++thread) {;
+//    first_index[thread] = (at_least + 1) * thread - (thread > remainder ? remainder : 0);
+    first_index[thread] = chunk_start(len, SAL_THREADS, thread);
+    first_good[thread] = len + 1;
+    first_bad[thread] = len + 1;
+    good[thread] = len + 1;
+    bad[thread] = len + 1;
+    printf("thread=%ld, first_index=%ld\n", thread, first_index[thread]);
+  }
+
+  for (long thread = 0; thread < SAL_THREADS; ++thread) {
+    long * cohort;
+    long thread_end = chunk_start(len, SAL_THREADS, thread + 1);
+    for (long i = first_index[thread]; i < thread_end && i < len; ++i) {
+      int absorbed = particles[i]._absorbed;
+      cohort = absorbed ? bad : good;
+      if (cohort[thread] < len){
+        nexts[cohort[thread]] = i; // from the head of the good/bad list next to the current node
+      } else {
+        if (absorbed){
+          first_bad[thread] = i;
+        } else {
+          first_good[thread] = i;
+        }
+      }
+      // update the good/bad list pointer to the current node
+      cohort[thread] = i;
+      // disconnect this node from the nexts list
+      nexts[i] = len + 1;
+    }
+  }
+  // move the good/bad pointers back to their first entries:
+  for (long thread = 0; thread < SAL_THREADS; ++thread) {
+    good[thread] = first_good[thread];
+    bad[thread] = first_bad[thread];
+  }
+  long total_good = connect_particle_nodes(good, nexts, len, SAL_THREADS, 1);
+  long total_bad = connect_particle_nodes(bad, nexts, len, SAL_THREADS, 0);
+
+  printf("total_good=%ld, total_bad=%ld\n", total_good, total_bad);
+
+  if (!(total_good && total_bad)){
+    return total_good;
+  }
+  if (multiplier){
+    *multiplier = 1 + total_bad / total_good;
+  }
+  // with finite good and bad, we have work to do.
+  // parallelize over the number of threads, each needs to fill-in total_bad / SAL_THREADS
+  at_least = total_bad / SAL_THREADS;
+  remainder = total_bad % SAL_THREADS;
+  // move the pointers to their per-thread offsets
+  for (long i=1; i<SAL_THREADS; i++) {
+    long chunk = i - 1 < remainder ? at_least + 1 : at_least;
+    bad[i] = particle_node_after(bad[i-1], nexts, len, chunk);
+    good[i] = particle_node_after(good[i-1], nexts, len, chunk);
+  }
+
+  // overwrite the bad list with the good list
+#pragma acc parallel loop present(particles[0:len], offsets[0:len], bad[0:SAL_THREADS], good[0:SAL_THREADS])
+  for (long thread=0; thread < SAL_THREADS; thread++) {
+    long chunk = thread < remainder ? at_least + 1 : at_least;
+    for (long i=0; i < chunk; ++i){
+      // copy the good particle to the bad list but don't copy it's randstate
+      long g = good[thread];
+      long b = bad[thread];
+      double randstate[6] = {
+          particles[b].randstate[0],
+          particles[b].randstate[1],
+          particles[b].randstate[2],
+          particles[b].randstate[3],
+          particles[b].randstate[4],
+          particles[b].randstate[5]
+      };
+
+      particles[b] = particles[g];
+      particles[b].randstate[0] = randstate[0];
+      particles[b].randstate[1] = randstate[1];
+      particles[b].randstate[2] = randstate[2];
+      particles[b].randstate[3] = randstate[3];
+      particles[b].randstate[4] = randstate[4];
+      particles[b].randstate[5] = -(double)thread; // randstate[5];
+
+      // move the pointers
+      bad[thread] = nexts[b];
+      good[thread] = nexts[g];
+    }
+  }
+
+  // we overwrote any bad particles, so we return the total number, always.
+  return len;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/sort_absorb_last.c
+++ b/sort_absorb_last.c
@@ -172,7 +172,6 @@ long sort_absorb_list(particle_node * input, long len, long * multiplier){
 #pragma acc parallel loop present(input[0:len], bad[0:SAL_THREADS], good[0:SAL_THREADS])
     for (long thread=0; thread < SAL_THREADS; thread++) {
       for (long i=0; i < (thread <= remainder ? at_least + 1 : at_least); ++i){
-        printf("Thread %ld, i %ld\n", thread, i);
         particle_node_copy(bad[thread], good[thread], 0); // don't copy the rand state from good to bad
         bad[thread] = bad[thread]->next;
         good[thread] = good[thread]->next;

--- a/sort_absorb_last.h
+++ b/sort_absorb_last.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "particle.h"
-
-long sort_absorb_last(_class_particle * particles, long len, _class_particle * pbuffer, long buffer_len, long flag_split, long* multiplier);
-
 long sort_absorb_list(particle_node * input, long len, long * multiplier);
+
+long sort_absorb_offset(_class_particle * particles, long * nexts, long len, long * multiplier);
+
+long chunk_start(long len, long threads, long thread);
+long chunk_size(long len, long threads, long thread);

--- a/sort_absorb_last.h
+++ b/sort_absorb_last.h
@@ -3,3 +3,5 @@
 #include "particle.h"
 
 long sort_absorb_last(_class_particle * particles, long len, _class_particle * pbuffer, long buffer_len, long flag_split, long* multiplier);
+
+long sort_absorb_list(particle_node * input, long len, long * multiplier);


### PR DESCRIPTION
The true linked-list implementation _is_ buggy and causes segmentation faults depending on input size.

This adds a 'pseudo' linked list that
1. requires the particles array be contiguous, which _should_ always be true anyway
2. uses a pre-allocated integer-array to keep track of the 'next' particle of the same absorbed/unabsorbed class 
3. builds a next-particle loop for unabsorbed particles, and a one-way path for absorbed particles
4. splits the path into `THREAD` parts which can each be traversed simultaneously 
5. each sub-path is traversed, replacing non-random-state particle parameters from the unabsorbed loop


## Further improvements
- The current implementation is tested using CTest for a set of specific cases, these test cases are not exhaustive but hopefully have identified most errors.
- The pre-allocated `next` array is currently pre-populated as well, but this should not be necessary.
- The one-way path is built from `THREAD` subpaths, each of which can be any length; then divided into subpaths of approximately-equal length. If the original subpaths are nearly the same length _anyway_, this step might be worth skipping.